### PR TITLE
refactor: pipe 함수 수정 

### DIFF
--- a/src/issue/api.js
+++ b/src/issue/api.js
@@ -1,11 +1,7 @@
-export const filterStatus = (status) => async (data) => {
-  const issueList = await data;
-  return issueList.filter((item) => item.status === status);
-};
+export const filterStatus = (status) => (list) => list.filter((item) => item.status === status);
 
-export const mapIssue = async (data) => {
-  const issueList = await data;
-  return issueList.map(({ title, tags, _id, status, openDate, milestones }) => ({
+export const mapIssue = (list) =>
+  list.map(({ title, tags, _id, status, openDate, milestones }) => ({
     title,
     tags,
     _id,
@@ -13,4 +9,3 @@ export const mapIssue = async (data) => {
     openDate,
     milestones,
   }));
-};

--- a/src/issue/event.js
+++ b/src/issue/event.js
@@ -1,26 +1,25 @@
 import { $ } from '../utils';
 import { setIssueListTpl } from './render';
+
 const toggleCountBtn = (setListTpl, $focused, $unfocused) => {
   setListTpl($('#issues'));
   $focused.style.fontWeight = 'bold';
   $unfocused.style.fontWeight = 'normal';
 };
 
-const addToggleCountEvent = ({ setListTpl, $target, $nontarget }) => {
-  $target.addEventListener('click', () => {
-    toggleCountBtn(setListTpl, $target, $nontarget);
-  });
+const addToggleCountEvent = ({ setListTpl, $target, $nonTarget }) => {
+  $target.addEventListener('click', () => toggleCountBtn(setListTpl, $target, $nonTarget));
 };
 
 export const addToggleCountEvents = (openStatusList, closeStatusList) => {
   addToggleCountEvent({
     setListTpl: setIssueListTpl(closeStatusList),
     $target: $('.close-count'),
-    $nontarget: $('.open-count'),
+    $nonTarget: $('.open-count'),
   });
   addToggleCountEvent({
     setListTpl: setIssueListTpl(openStatusList),
     $target: $('.open-count'),
-    $nontarget: $('.close-count'),
+    $nonTarget: $('.close-count'),
   });
 };

--- a/src/utils/fn.js
+++ b/src/utils/fn.js
@@ -1,6 +1,6 @@
 export const pipe =
   (...fns) =>
   (initialValue) =>
-    fns.reduce((acc, fn) => fn(acc), initialValue);
+    fns.reduce((acc, fn) => (acc instanceof Promise ? acc.then(fn) : fn(acc)), initialValue);
 
 export const go = (a, ...fns) => fns.reduce((acc, fn) => fn(acc), a);


### PR DESCRIPTION
## 주요 변경사항
- pipe 함수에 Promise 객체 여부 판단 로직 추가
   - filterStatus, mapIssue 함수들이 `data` 가 Promise 라는 걸 알고 있는게 맞나 싶은 생각이 들었어요
   - 그래서 이 함수 내부가 아닌, pipe 에서 Promise인지 아닌지를 판단하는 로직을 추가하였습니다
   - pipe의 유틸성을 해치지 않으면서 Promise 도 다룰 수 있는 방향으로 수정해보았습니다 
- 그 외 오타, 함수 인라인 등 자잘한 수정 진행했습니다 